### PR TITLE
Add hourly logrotate configuration for Vault logs using systemd timer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 locals {
   ssm_path_vault_recovery_keys_b64 = var.ssm_path_vault_recovery_keys_b64 != "" ? var.ssm_path_vault_recovery_keys_b64 : "/${var.name}/recovery_keys_b64"
-  
+
   ssm_path_vault_root_token = var.ssm_path_vault_root_token != "" ? var.ssm_path_vault_root_token : "/${var.name}/root_token"
-  
+
 }
 
 #--------------------------------------------------------------------
@@ -183,7 +183,7 @@ data "aws_iam_policy_document" "vault_role_policy" {
     effect    = "Allow"
     actions   = ["sts:GetCallerIdentity"]
     resources = ["*"]
-  }  
+  }
 
   # statement {
   #   sid     = "PCAIssueCert"
@@ -304,23 +304,21 @@ resource "aws_security_group" "vault_cluster" {
 #--------------------------------------------------------------------
 
 resource "aws_launch_template" "vault" {
-  tags                   = var.tags
-  name                   = var.name
-  description            = "Vault cluster ${var.name} launch template"
-  image_id               = data.aws_ami.vault.id
-  user_data              = base64encode(templatefile(
+  tags        = var.tags
+  name        = var.name
+  description = "Vault cluster ${var.name} launch template"
+  image_id    = data.aws_ami.vault.id
+  user_data = base64encode(templatefile(
     "${path.module}/userdata.sh",
     {
-      aws_region         = var.region
-      kms_key_id         = aws_kms_key.vault.key_id
-      dynamodb_table     = aws_dynamodb_table.vault.name
-      acm_pca_arn        = var.acm_pca_arn
+      aws_region               = var.region
+      kms_key_id               = aws_kms_key.vault.key_id
+      dynamodb_table           = aws_dynamodb_table.vault.name
+      acm_pca_arn              = var.acm_pca_arn
       cluster_name             = var.name
       cluster_fqdn             = aws_route53_record.vault.fqdn
       dogstatsd_tags           = var.dogstatsd_tags
       ssm_path_datadog_api_key = var.ssm_path_datadog_api_key
-      ssm_path_sumo_access_id  = var.ssm_path_sumologic_access_id
-      ssm_path_sumo_access_key = var.ssm_path_sumologic_access_key
     }
   ))
   instance_type          = var.instance_type
@@ -345,7 +343,7 @@ resource "aws_launch_template" "vault" {
 
   tag_specifications {
     resource_type = "instance"
-    tags          = merge({"Name"=var.name},var.tags)
+    tags          = merge({ "Name" = var.name }, var.tags)
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -319,6 +319,7 @@ resource "aws_launch_template" "vault" {
       cluster_fqdn             = aws_route53_record.vault.fqdn
       dogstatsd_tags           = var.dogstatsd_tags
       ssm_path_datadog_api_key = var.ssm_path_datadog_api_key
+      environment              = var.environment
     }
   ))
   instance_type          = var.instance_type

--- a/userdata.sh
+++ b/userdata.sh
@@ -109,7 +109,38 @@ cat > /etc/logrotate.d/vault-audit <<'EOF'
 EOF
 
 # setting hourly has no effect unless logrotate actually runs hourly using cron
-mv /etc/cron.daily/logrotate /etc/cron.hourly/
+
+# check if /etc/cron.daily/logrotate exists. This does not exist on Amazon Linux 2023
+# if is does not exit, configure use systemd timer for hourly logrotate
+if [ -f /etc/cron.daily/logrotate ]; then
+  mv /etc/cron.daily/logrotate /etc/cron.hourly/
+else
+  # Create an hourly systemd timer + service for logrotate
+cat >/etc/systemd/system/logrotate-hourly.service <<'EOF'
+[Unit]
+Description=Run logrotate hourly
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate /etc/logrotate.conf
+EOF
+
+cat >/etc/systemd/system/logrotate-hourly.timer <<'EOF'
+[Unit]
+Description=Run logrotate hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now logrotate-hourly.timer
+fi
+
 
 #--------------------------------------------------------------------
 # Generate Vault's TLS certificate and key

--- a/userdata.sh
+++ b/userdata.sh
@@ -12,7 +12,11 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 # Set useful variables
 #--------------------------------------------------------------------
 export AWS_DEFAULT_REGION=${aws_region}
-SELF_PRIVATE_IP="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
+# IMDSv2
+IMDS_TOKEN="$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+SELF_PRIVATE_IP="$(curl -sf -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
+  http://169.254.169.254/latest/meta-data/local-ipv4)"
 
 #--------------------------------------------------------------------
 # Install Datadog Agent
@@ -20,6 +24,13 @@ SELF_PRIVATE_IP="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 export DD_API_KEY="$(aws ssm get-parameter --name "${ssm_path_datadog_api_key}" --with-decryption | jq -r '.Parameter.Value')"
 export DD_LOGS_ENABLED=true
 DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+
+# Make sure logs are enabled in config (idempotent)
+if grep -q '^[#[:space:]]*logs_enabled:' /etc/datadog-agent/datadog.yaml; then
+  sed -i 's/^[#[:space:]]*logs_enabled:.*/logs_enabled: true/' /etc/datadog-agent/datadog.yaml
+else
+  echo 'logs_enabled: true' >> /etc/datadog-agent/datadog.yaml
+fi
 
 mkdir -p /etc/datadog-agent/conf.d/http_check.d
 cat > /etc/datadog-agent/conf.d/http_check.d/conf.yaml <<EOF
@@ -30,26 +41,33 @@ instances:
     url: https://${cluster_fqdn}
 EOF
 
-# Datadog log collection (replaces Sumo Logic): syslog and Vault audit logs
-mkdir -p /etc/datadog-agent/conf.d/vault.d
-cat > /etc/datadog-agent/conf.d/vault.d/conf.yaml <<EOF
+# Journald log collection for vault.service
+mkdir -p /etc/datadog-agent/conf.d/journald.d
+cat >/etc/datadog-agent/conf.d/journald.d/conf.yaml <<'EOF'
 logs:
-  - type: file
-    path: /var/log/messages
-    service: vault
-    source: syslog
-    tags: ["cluster_name:${cluster_name}"]
-  - type: file
-    path: /var/log/secure
-    service: vault
-    source: syslog
-    tags: ["cluster_name:${cluster_name}"]
-  - type: file
-    path: /var/log/vault/audit.log
+  - type: journald
     service: vault
     source: vault
-    tags: ["cluster_name:${cluster_name}"]
+    filter_unit: vault.service
 EOF
+
+# Vault audit log file permissions for Datadog (optional but recommended)
+dnf install -y acl
+mkdir -p /var/log/vault
+chown vault:vault /var/log/vault
+touch /var/log/vault/audit.log
+chown vault:vault /var/log/vault/audit.log
+setfacl -m u:dd-agent:r /var/log/vault/audit.log || true
+
+if ! grep -q '^tags:' /etc/datadog-agent/datadog.yaml; then
+  cat >>/etc/datadog-agent/datadog.yaml <<EOF
+
+tags:
+  - "vault_cluster:${cluster_name}"
+  - "env:${environment}"
+  - "role:vault"
+EOF
+fi
 
 systemctl restart datadog-agent
 
@@ -69,6 +87,7 @@ cat > /etc/logrotate.d/vault-audit <<'EOF'
   compress
   postrotate
     kill -HUP $(cat /var/run/vault/vault.pid)
+    setfacl -m u:dd-agent:r /var/log/vault/audit.log || true
   endscript
 }
 EOF

--- a/userdata.sh
+++ b/userdata.sh
@@ -69,6 +69,8 @@ tags:
 EOF
 fi
 
+usermod -aG systemd-journal dd-agent || true
+
 systemctl restart datadog-agent
 
 #--------------------------------------------------------------------

--- a/userdata.sh
+++ b/userdata.sh
@@ -18,6 +18,7 @@ SELF_PRIVATE_IP="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 # Install Datadog Agent
 #--------------------------------------------------------------------
 export DD_API_KEY="$(aws ssm get-parameter --name "${ssm_path_datadog_api_key}" --with-decryption | jq -r '.Parameter.Value')"
+export DD_LOGS_ENABLED=true
 DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
 mkdir -p /etc/datadog-agent/conf.d/http_check.d
@@ -28,65 +29,29 @@ instances:
   - name: vault_http_check
     url: https://${cluster_fqdn}
 EOF
-systemctl restart datadog-agent
 
-#--------------------------------------------------------------------
-# Install Sumo Logic Collector
-#--------------------------------------------------------------------
-mkdir -p /opt/SumoCollector
-
-cat > /opt/SumoCollector/sources.json <<EOF
-{
-  "api.version": "v1",
-  "sources": [
-    {
-      "name": "SyslogMessages",
-      "sourceType": "LocalFile",
-      "automaticDateParsing": true,
-      "multilineProcessingEnabled": false,
-      "useAutolineMatching": true,
-      "forceTimeZone": false,
-      "timeZone": "UTC",
-      "category": "Vault/${cluster_name}",
-      "pathExpression": "/var/log/messages"
-    },
-    {
-      "name": "SyslogSecure",
-      "sourceType": "LocalFile",
-      "automaticDateParsing": true,
-      "multilineProcessingEnabled": false,
-      "useAutolineMatching": true,
-      "forceTimeZone": false,
-      "timeZone": "UTC",
-      "category": "Vault/${cluster_name}",
-      "pathExpression": "/var/log/secure"
-    },
-    {
-      "name": "VaultAudit",
-      "sourceType": "LocalFile",
-      "automaticDateParsing": true,
-      "multilineProcessingEnabled": false,
-      "useAutolineMatching": true,
-      "forceTimeZone": false,
-      "timeZone": "UTC",
-      "category": "Vault/${cluster_name}",
-      "pathExpression": "/var/log/vault/audit.log"
-    }
-  ]
-}
+# Datadog log collection (replaces Sumo Logic): syslog and Vault audit logs
+mkdir -p /etc/datadog-agent/conf.d/vault.d
+cat > /etc/datadog-agent/conf.d/vault.d/conf.yaml <<EOF
+logs:
+  - type: file
+    path: /var/log/messages
+    service: vault
+    source: syslog
+    tags: ["cluster_name:${cluster_name}"]
+  - type: file
+    path: /var/log/secure
+    service: vault
+    source: syslog
+    tags: ["cluster_name:${cluster_name}"]
+  - type: file
+    path: /var/log/vault/audit.log
+    service: vault
+    source: vault
+    tags: ["cluster_name:${cluster_name}"]
 EOF
 
-SUMO_ACCESS_ID="$(aws ssm get-parameter --name "${ssm_path_sumo_access_id}" | jq -r '.Parameter.Value')"
-SUMO_ACCESS_KEY="$(aws ssm get-parameter --name "${ssm_path_sumo_access_key}" --with-decryption | jq -r '.Parameter.Value')"
-wget "https://collectors.sumologic.com/rest/download/linux/64" -O SumoCollector.sh
-chmod +x SumoCollector.sh
-./SumoCollector.sh -q \
-  -dir="/opt/SumoCollector" \
-  -Vsumo.accessid="$SUMO_ACCESS_ID" \
-  -Vsumo.accesskey="$SUMO_ACCESS_KEY" \
-  -Vdescription="Vault cluster ${cluster_name}" \
-  -VsyncSources="/opt/SumoCollector/sources.json" \
-  -Vephemeral=true
+systemctl restart datadog-agent
 
 #--------------------------------------------------------------------
 # Configure Logrotate ('EOF' so the subshell doesn't execute)


### PR DESCRIPTION
This pull request improves how log rotation is scheduled on systems where the default cron-based logrotate job may not exist, such as Amazon Linux 2023. It ensures that log rotation runs hourly regardless of the underlying distribution by conditionally setting up either a cron job or a systemd timer.

Log rotation scheduling improvements:
* Checks if `/etc/cron.daily/logrotate` exists; if it does, moves it to `/etc/cron.hourly/` to enable hourly log rotation.
* If the cron job does not exist (e.g., on Amazon Linux 2023), creates a new `logrotate-hourly.service` and `logrotate-hourly.timer` systemd unit to run logrotate hourly, and enables the timer.